### PR TITLE
Provide babel with caller info

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ var esprima = require('esprima');
 var glob = require('glob');
 var resolveGlob = require('./resolve-glob');
 
-var babelOptions = {};
+var babelOptions = { caller: { name: 'find-imports' } };
 try {
-    babelOptions = JSON.parse(fs.readFileSync('.babelrc', 'utf-8'));
+    Object.assign(babelOptions, JSON.parse(fs.readFileSync('.babelrc', 'utf-8')));
 } catch (e) {
     // No custom babel configuration found - using defaults
 }


### PR DESCRIPTION
Hi @cheton,

Would you be okay with adding in a [caller](https://babeljs.io/docs/en/options#caller) option to the babel call? It would help projects using `find-imports` to be able to differentiate between the different utilities calling babel.

Thank!
